### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 Your browser does not support the video tag.
 </video>
 
+<a href="https://glama.ai/mcp/servers/@rmarescu/gumroad-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@rmarescu/gumroad-mcp/badge" alt="Gumroad MCP server" />
+</a>
+
 ## Overview
 
 A Model Context Protocol (MCP) server implementation for [Gumroad](https://gumroad.com), enabling MCP-compatible AI clients like Claude Desktop to interact with [Gumroad's API](https://gumroad.com/api).


### PR DESCRIPTION
This PR adds a badge for the [Gumroad](https://glama.ai/mcp/servers/@rmarescu/gumroad-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@rmarescu/gumroad-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@rmarescu/gumroad-mcp/badge" alt="Gumroad MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.